### PR TITLE
Complete refactoring from agentbench to acbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ tasks=(wikihow toolbench toolalpaca lumos alfworld webshop os)
 MODEL_NAME=$(basename $MODEL)
 
 for task in ${tasks[@]}; do
-    python agentbench/node_eval.py \
+    python acbench/node_eval.py \
         --task gen_workflow \
         --model_name ${MODEL} \
         --gold_path ./data/gold_traj/${task}/graph_eval.json \

--- a/acbench/node_eval.py
+++ b/acbench/node_eval.py
@@ -5,10 +5,10 @@ import os
 import re
 from tqdm import tqdm
 
-from agentbench.llm.localLLM import VllmLocalLLM, VllmOfflineModel
+from acbench.llm.localLLM import VllmLocalLLM, VllmOfflineModel
 
-from agentbench.evaluator.graph_evaluator import t_eval_graph, t_eval_nodes
-from agentbench.prompts.eval_prompt import two_shot_example as example
+from acbench.evaluator.graph_evaluator import t_eval_graph, t_eval_nodes
+from acbench.prompts.eval_prompt import two_shot_example as example
 
 
 def workflow_to_node_list(workflow: str) -> List[str]:
@@ -109,7 +109,7 @@ def gen_workflow(
         dtype=args.dtype,
         device=args.device,
         tensor_parallel_size=args.tensor_parallel_size,
-        block_size=16
+        block_size=16,
     )
 
     with open(gold_path, "r") as f:

--- a/scripts/eval.sh
+++ b/scripts/eval.sh
@@ -12,7 +12,7 @@ tasks=(os wikihow toolbench toolalpaca lumos alfworld webshop)
 MODEL_NAME=$(basename $MODEL)
 
 for task in ${tasks[@]}; do
-    python agentbench/node_eval.py \
+    python acbench/node_eval.py \
         --task eval_workflow \
         --model_name ${MODEL} \
         --gold_path ./data/gold_traj/${task}/graph_eval.json \

--- a/scripts/quant.sh
+++ b/scripts/quant.sh
@@ -30,56 +30,56 @@ python quant/autoawq.py \
     --w_bit 4 \
     --version gemm 
 
-python agentbench/quant/llm_compressor_vllm.py \
+python acbench/quant/llm_compressor_vllm.py \
      --model_path /data2/share/llama3.2/Llama-3.2-1B-Instruct \
      --quant_method smoothquant > ./logs/llama3.2-smoothquant.log
     
-python agentbench/quant/llm_compressor_vllm.py \
+python acbench/quant/llm_compressor_vllm.py \
     --model_path /data2/share/llama3.1/llama-3.1-8B-Instruct \
     --quant_method smoothquant > ./logs/llama3.1-smoothquant.log
 
-CUDA_VISIBLE_DEVICES=3 python agentbench/quant/llm_compressor_vllm.py \
+CUDA_VISIBLE_DEVICES=3 python acbench/quant/llm_compressor_vllm.py \
     --model_path /data2/share/llama3.1/llama-3.1-8B-Instruct \
     --quant_method gptq > ./logs/llama3.1-gptq.log &
 
-python agentbench/quant/llm_compressor_vllm.py \
+python acbench/quant/llm_compressor_vllm.py \
     --model_path /data2/share/mistral-7B/Mistral-7B-Instruct-v0.3 \
     --quant_method smoothquant > ./logs/mistral-7B-smoothquant.log
 
-CUDA_VISIBLE_DEVICES=4 python agentbench/quant/llm_compressor_vllm.py \
+CUDA_VISIBLE_DEVICES=4 python acbench/quant/llm_compressor_vllm.py \
     --model_path /data2/share/mistral-7B/Mistral-7B-Instruct-v0.3 \
     --quant_method gptq > ./logs/mistral-7B-gptq.log &
 
-CUDA_VISIBLE_DEVICES=5 python agentbench/quant/llm_compressor_vllm.py \
+CUDA_VISIBLE_DEVICES=5 python acbench/quant/llm_compressor_vllm.py \
     --model_path /data2/share/Qwen2.5/Qwen2.5-7B-Instruct \
     --quant_method gptq > ./logs/Qwen2.5-7B-gptq.log &
 
-CUDA_VISIBLE_DEVICES=3 python agentbench/quant/llm_compressor_vllm.py \
+CUDA_VISIBLE_DEVICES=3 python acbench/quant/llm_compressor_vllm.py \
     --model_path /data2/share/Qwen2.5/Qwen2.5-7B-Instruct \
     --quant_method smoothquant > ./logs/Qwen2.5-7B-smoothquant.log &
 
-CUDA_VISIBLE_DEVICES=4 python agentbench/quant/llm_autoawq.py \
+CUDA_VISIBLE_DEVICES=4 python acbench/quant/llm_autoawq.py \
     --model_path /data2/share/llama3.2/Llama-3.2-1B-Instruct \
     --zero_point True \
     --q_group_size 128 \
     --w_bit 4 \
     --version gemm &
 
-CUDA_VISIBLE_DEVICES=5 python agentbench/quant/llm_autoawq.py \
+CUDA_VISIBLE_DEVICES=5 python acbench/quant/llm_autoawq.py \
     --model_path /data2/share/llama3.1/llama-3.1-8B-Instruct \
     --zero_point True \
     --q_group_size 128 \
     --w_bit 4 \
     --version gemm &
 
-CUDA_VISIBLE_DEVICES=6 python agentbench/quant/llm_autoawq.py \
+CUDA_VISIBLE_DEVICES=6 python acbench/quant/llm_autoawq.py \
     --model_path /data2/share/Qwen2.5/Qwen2.5-7B-Instruct \
     --zero_point True \
     --q_group_size 128 \
     --w_bit 4 \
     --version gemm 
 
-CUDA_VISIBLE_DEVICES=6 python agentbench/quant/llm_autoawq.py \
+CUDA_VISIBLE_DEVICES=6 python acbench/quant/llm_autoawq.py \
     --model_path /data2/share/mistral-7B/Mistral-7B-Instruct-v0.3 \
     --zero_point True \
     --q_group_size 128 \

--- a/scripts/run_eval_rested.sh
+++ b/scripts/run_eval_rested.sh
@@ -83,7 +83,7 @@ function run_slm_EVALFLOW() {
         eval_output_file="./data/eval_result/${model_name}/${model_name}_${task}_graph_eval_two_shot.json"
         if [ ! -f "$eval_output_file" ]; then
             echo "Running evaluation for task $task as output not found"
-            python agentbench/node_eval.py \
+            python acbench/node_eval.py \
                 --task eval_workflow \
                 --model_name ${model_path} \
                 --gold_path ./data/gold_traj/${task}/graph_eval.json \

--- a/scripts/run_gen_rested.sh
+++ b/scripts/run_gen_rested.sh
@@ -64,7 +64,7 @@ function run_slm_genflow() {
         result_file="./data/pred_traj/${model_name}/${task}/${model_name}/graph_eval_two_shot.json"
         if [ ! -f "$result_file" ]; then
             echo "Running task $task for model $model_key as result not found"
-            python agentbench/node_eval.py \
+            python acbench/node_eval.py \
                 --task gen_workflow \
                 --model_name ${model_path} \
                 --gold_path ./data/gold_traj/${task}/graph_eval.json \


### PR DESCRIPTION
The name "ACBench" was introduced in commit 98759ba from the original "agentbench". However, it is still present in some import statements of the python code, as well as in some path parameters of the scripts, which lead to exceptions when trying to execute the benchmark. This PR aims to change the naming in crucial places. 